### PR TITLE
負数の小数部を正方向に切り捨てる

### DIFF
--- a/js/ktr.js
+++ b/js/ktr.js
@@ -543,7 +543,7 @@
                     const difference = actualWorkingMinutes - actualWorkingDays * normalWorkingMinutesPerDay;
                     // `n時間m分`の形式で表示
                     const sign = Math.sign(difference) >= 0 ? '+' : ''
-                    const differenceStr = `${sign}${Math.floor(difference / 60)}時間${difference % 60}分`;
+                    const differenceStr = `${sign}${Math.trunc(difference / 60)}時間${difference % 60}分`;
                     cb(differenceStr);
                 });
         },


### PR DESCRIPTION
Math.floor は引数以下の最大の整数を返すので、負の数を与えると負方向に小数部が切り捨てられ、勤務時間差において1時間のずれが生じてしまいます。

```javascript
const difference = -10;

console.log(difference / 60); // -0.16666666666666666
console.log(Math.floor(difference / 60)); // -1
```

Google Chrome では [Math.trunc](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc) が利用できるので、これを使って負数の小数部を正方向に切り捨てるようにしました。