### PR TITLE
勤怠状況を確認できるようにした

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -1,105 +1,143 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-<meta charset="utf-8">
-<title>勤之助タイムレコーダー</title>
-<style>
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-body {
-  width: 200px;
-  padding: 10px;
-  font: 100%/1.5 sans-serif;
-}
-.inout-block {
-  display: none;
-  padding: 5px 0 10px;
-  width: 100%;
-}
-.inout {
-  display: table-cell;
-  width: 50%;
-  padding: 4px 0;
-  text-align: center;
-  color: #999;
-}
-ul {
-  list-style-type: none;
-}
-li {
-  display: block;
-  padding: 4px 20px;
-  text-align: left;
-  color: #999;
-}
-.enabled {
-  cursor: pointer;
-  color: #00f;
-}
-.enabled:hover {
-  background: #cce0ff;
-}
-.attention {
-  color: #f30;
-}
-.menu img {
-  height: 20px;
-  margin-right: 5px;
-  vertical-align: middle;
-}
-.modal {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: lightgray;
-  opacity: 0.8;
-}
-.dialog {
-  position: absolute;
-  width: 158px;
-  margin: 0 10px;
-  padding: 10px 0;
-  border: 1px solid gray;
-  border-radius: 3px;
-  background: #fff;
-  text-align: center;
-}
-button {
-  min-height: 1.5em;
-  margin-top: 6px;
-  padding: 2px 0 0;
-  border: 1px solid rgba(0, 0, 0, 0.25);
-  border-radius: 2px;
-  background-image: -webkit-linear-gradient(#ededed, #ededed 38%, #dedede);
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08), inset 0 1px 2px rgba(255, 255, 255, 0.75);
-  font: inherit;
-  font-size: 80%;
-  color: #444;
-  text-shadow: 0 1px 0 rgb(240, 240, 240);
-}
-button.confirm {
-  width: 64px;
-}
-button.confirm:last-child {
-  margin-left: 10px;
-}
-</style>
-<script src="/vendor/jquery.js"></script>
-<script src="/vendor/crypto-js.js"></script>
-<script src="/js/ktr.js"></script>
-<script src="/js/popup.js"></script>
+  <meta charset="utf-8">
+  <title>勤之助タイムレコーダー</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      width: 200px;
+      padding: 10px;
+      font: 100%/1.5 sans-serif;
+    }
+    .inout-block {
+      display: none;
+      padding: 5px 0 10px;
+      width: 100%;
+    }
+    .inout {
+      display: table-cell;
+      width: 50%;
+      padding: 4px 0;
+      text-align: center;
+      color: #999;
+    }
+    ul {
+      list-style-type: none;
+    }
+    li {
+      display: block;
+      padding: 4px 20px;
+      text-align: left;
+      color: #999;
+    }
+    .enabled {
+      cursor: pointer;
+      color: #00f;
+    }
+    .enabled:hover {
+      background: #cce0ff;
+    }
+    .attention {
+      color: #f30;
+    }
+    .menu img {
+      height: 20px;
+      margin-right: 5px;
+      vertical-align: middle;
+    }
+    .modal {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: lightgray;
+      opacity: 0.8;
+    }
+    .dialog {
+      position: absolute;
+      width: 158px;
+      margin: 0 10px;
+      padding: 10px 0;
+      border: 1px solid gray;
+      border-radius: 3px;
+      background: #fff;
+      text-align: center;
+    }
+    button {
+      min-height: 1.5em;
+      margin-top: 6px;
+      padding: 2px 0 0;
+      border: 1px solid rgba(0, 0, 0, 0.25);
+      border-radius: 2px;
+      background-image: -webkit-linear-gradient(#ededed, #ededed 38%, #dedede);
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08), inset 0 1px 2px rgba(255, 255, 255, 0.75);
+      font: inherit;
+      font-size: 80%;
+      color: #444;
+      text-shadow: 0 1px 0 rgb(240, 240, 240);
+    }
+    button.confirm {
+      width: 64px;
+    }
+    button.confirm:last-child {
+      margin-left: 10px;
+    }
+    .time-table { width: 100%; display: none; }
+    .time-table th, .time-table td { font-size: 70%; text-align: right; border-bottom: 1px solid #dedede; border-collapse: collapse; }
+  </style>
+  <script src="/vendor/jquery.js"></script>
+  <script src="/vendor/crypto-js.js"></script>
+  <script src="/js/ktr.js"></script>
+  <script src="/js/popup.js"></script>
 </head>
 <body>
 <div class="inout-block">
   <p id="action1" class="inout">出社</p>
   <p id="action2" class="inout">退社</p>
 </div>
-<div id="diff" class="enabled">フレックス時間差</div>
+
+<div id="diff" class="enabled">
+  <p style="padding: 4px 20px;">🕒  勤務時間</p>
+  <table class="time-table">
+    <tr>
+      <th width="20%"></th>
+      <th width="40%">勤務日数</th>
+      <th width="40%">勤務時間</th>
+    </tr>
+    <tr>
+      <th>所定</th>
+      <td id="fd"></td>
+      <td id="ft"></td>
+    </tr>
+    <tr>
+      <th>現在</th>
+      <td id="ad"></td>
+      <td id="at"></td>
+    </tr>
+    <tr>
+      <th>必要</th>
+      <td id="nd"></td>
+      <td id="nt"></td>
+    </tr>
+    <tr>
+      <th colspan="2">一日あたり勤務時間</th>
+      <td id="tpd"></td>
+    </tr>
+    <tr>
+      <th colspan="2">今日の勤務時間 ※</th>
+      <td id="tt"></td>
+    </tr>
+    <tr>
+      <td colspan="3"><small>※ 休憩時間を含む</small></td>
+    </tr>
+  </table>
+</div>
 <ul>
   <li id="service" class="enabled">勤之助を開く</li>
   <li id="options" class="enabled">オプション</li>

--- a/js/popup.js
+++ b/js/popup.js
@@ -13,7 +13,16 @@ function init() {
     const $options = $('#options');
     const $diff = $('#diff');
     $diff.click(() => KTR.service.getDifference((diff) => {
-        $('#diff').text(diff).removeClass('enabled');
+        $('#diff').removeClass('enabled');
+        $('#fd').text(`${diff.days.fixed}日`);
+        $('#ad').text(`${diff.days.actual}日`);
+        $('#nd').text(`${diff.days.need}日`);
+        $('#ft').text(`${diff.times.fixed.hour}:${diff.times.fixed.min}`);
+        $('#at').text(`${diff.times.actual.hour}:${diff.times.actual.min}`);
+        $('#nt').text(`${diff.times.need.hour}:${diff.times.need.min}`);
+        $('#tpd').text(`${diff.times.perDay.hour}:${diff.times.perDay.min}`);
+        $('#tt').text(`${diff.times.today.hour}:${diff.times.today.min}`);
+        $('#diff .time-table').fadeIn();
     }));
 
     // 認証情報があれば出社、退社を表示


### PR DESCRIPTION
## P/R is
勤務状況の詳細を確認できるようにしました。
これによってログインせずにあと何日で何時間ずつ働く必要があるのかなどを確認できます。

具体的な画面イメージは下記図をご覧ください。

| 修正前 | 修正後 |
| --- | --- |
| <img width="197" alt="2019-01-18 10 15 06" src="https://user-images.githubusercontent.com/24952964/51360341-92ecdf00-1b0e-11e9-9737-17bdb064d821.png"> | <img width="196" alt="2019-01-18 10 37 47" src="https://user-images.githubusercontent.com/24952964/51360338-92544880-1b0e-11e9-9d27-2ffafa60ce15.png"> |

**修正した点**

- 所定勤務時間に対する現在の勤務時間を表示できるようにした
    - 勤之助のサマリーテーブルをそのまま表示している
- 必要勤務時間と必要残就業日数から一日あたりの必要勤務時間を算出するようにした
    - 算出式： `(所定労働時間 - 実働時間) / (所定労働日数 - 出勤日数 - 有給日数 - 特休日数)`
- 打刻した時点から今現在までで何時間勤務しているかを動的に算出するようにした
    - 算出式： `(今の時刻 - 今日の出社時刻)`
    - 休憩時間の計算は行っていない